### PR TITLE
Improve the performance of the R2DBC smart driver

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
@@ -122,7 +122,7 @@ public final class PostgresqlConnectionFactory implements ConnectionFactory {
         String chosenHost = null;
         UniformLoadBalancerConnectionStrategy connectionStrategy = getAppropriateLoadBlancer();
         List<String> hosts = this.configuration.getHosts();
-            if (chosenHost == null) {
+            if (chosenHost == null && controlConnection == null) {
                 for (Iterator<String> iterator = hosts.iterator(); iterator.hasNext();) {
                     String host = iterator.next();
                     ConnectionFunction connectionFunction = new SingleHostConnectionFunction(this.connectionFunction, this.configuration);
@@ -142,7 +142,7 @@ public final class PostgresqlConnectionFactory implements ConnectionFactory {
         if (controlConnection == null || !connectionStrategy.refresh(controlConnection)) {
             return null;
         }
-        controlConnection.close().block();
+//        controlConnection.close().block();
         chosenHost = connectionStrategy.getHostWithLeastConnections();
 
         if (chosenHost == null)

--- a/src/main/java/io/r2dbc/postgresql/SingleHostConnectionStrategy.java
+++ b/src/main/java/io/r2dbc/postgresql/SingleHostConnectionStrategy.java
@@ -38,12 +38,7 @@ final class SingleHostConnectionStrategy implements ConnectionStrategy {
 
     @Override
     public Mono<Client> connect() {
-//        long startTime = System.nanoTime();
-//        Mono<Client> client =
           return this.connectionFunction.connect(this.endpoint, this.connectionSettings);
-//        long endTime = System.nanoTime();
-//        System.out.println("Connect() Created in " + (endTime - startTime)/1000000.0);
-//        return client;
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/SingleHostConnectionStrategy.java
+++ b/src/main/java/io/r2dbc/postgresql/SingleHostConnectionStrategy.java
@@ -38,7 +38,12 @@ final class SingleHostConnectionStrategy implements ConnectionStrategy {
 
     @Override
     public Mono<Client> connect() {
-        return this.connectionFunction.connect(this.endpoint, this.connectionSettings);
+//        long startTime = System.nanoTime();
+//        Mono<Client> client =
+          return this.connectionFunction.connect(this.endpoint, this.connectionSettings);
+//        long endTime = System.nanoTime();
+//        System.out.println("Connect() Created in " + (endTime - startTime)/1000000.0);
+//        return client;
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/UniformLoadBalancerConnectionStrategy.java
+++ b/src/main/java/io/r2dbc/postgresql/UniformLoadBalancerConnectionStrategy.java
@@ -105,12 +105,9 @@ public class UniformLoadBalancerConnectionStrategy implements ConnectionStrategy
     }
 
     public Mono<Client> connect(String host) {
-//        long startTime = System.nanoTime();
         incDecConnectionCount(host, 1);
         endpoint = InetSocketAddress.createUnresolved(host, 5433);
         Mono<Client> client = this.connectionFunction.connect(endpoint, this.connectionSettings);
-//        long endTime = System.nanoTime();
-//        System.out.println("Connect() Method in " + (endTime - startTime)/1000000.0);
         return client;
     }
 

--- a/src/main/java/io/r2dbc/postgresql/UniformLoadBalancerConnectionStrategy.java
+++ b/src/main/java/io/r2dbc/postgresql/UniformLoadBalancerConnectionStrategy.java
@@ -105,9 +105,12 @@ public class UniformLoadBalancerConnectionStrategy implements ConnectionStrategy
     }
 
     public Mono<Client> connect(String host) {
+//        long startTime = System.nanoTime();
         incDecConnectionCount(host, 1);
         endpoint = InetSocketAddress.createUnresolved(host, 5433);
         Mono<Client> client = this.connectionFunction.connect(endpoint, this.connectionSettings);
+//        long endTime = System.nanoTime();
+//        System.out.println("Connect() Method in " + (endTime - startTime)/1000000.0);
         return client;
     }
 
@@ -127,10 +130,11 @@ public class UniformLoadBalancerConnectionStrategy implements ConnectionStrategy
         return false;
     }
 
-    public synchronized boolean refresh(PostgresqlConnection controlConnection) {
+    public synchronized boolean refresh( Mono<PostgresqlConnection> controlConn) {
         if (!needsRefresh()) {
             return true;
         }
+        PostgresqlConnection controlConnection = controlConn.block();
         // else clear server list
         long currTime = System.currentTimeMillis();
         lastServerListFetchTime = currTime;

--- a/src/main/java/io/r2dbc/postgresql/UniformLoadBalancerConnectionStrategy.java
+++ b/src/main/java/io/r2dbc/postgresql/UniformLoadBalancerConnectionStrategy.java
@@ -176,6 +176,7 @@ public class UniformLoadBalancerConnectionStrategy implements ConnectionStrategy
                 }
             }
         }
+        controlConnection.close().block();
         return true;
     }
 


### PR DESCRIPTION
Currently the R2DBC Driver has a performance degradation of 180% compared to the upstream driver. The changes made are to improve the performance of the R2dbc driver by avoiding blocking calls.

Changes made:
The control connection blocking call is only done when refresh is called
The new connection blocking call is only called when a better node is available
Since block call is removed for every connection, when a node goes down, onErrorResume() API is called which calls the createloadbalancedconnection() again for new node selection.
Bug fix : Control connection was getting created for every new connection creation, made it single connection. 

Tests run:
Tests in the repository path `src/test/java/com/yugabyte`
Performance tests with comparison with the upstream driver. Results of perf test: https://docs.google.com/spreadsheets/d/1kW1pl_KGkqwCYXgN1UfUAgzZyGPhJyezy6PTyLxA7_I/edit?usp=sharing