### PR TITLE
Fix r2dbc-pool compatibility for load-balanced connections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,12 @@
 
         <!-- Test Dependencies -->
         <dependency>
+            <groupId>io.r2dbc</groupId>
+            <artifactId>r2dbc-pool</artifactId>
+            <version>1.0.1.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
@@ -102,19 +102,25 @@ public final class PostgresqlConnectionFactory implements ConnectionFactory {
     @Override
     public Mono<io.r2dbc.postgresql.api.PostgresqlConnection> create() {
 
-        if (isReplicationConnection()) {
-            throw new UnsupportedOperationException("Cannot create replication connection through create(). Use replication() method instead.");
-        }
-
-        if (this.configuration.isLoadBalanced()) {
-            Mono<io.r2dbc.postgresql.api.PostgresqlConnection> conn = createLoadBalancedConnection();
-            if (conn != null) {
-                return conn;
+        // Mono.defer: r2dbc-pool calls factory.create() once and resubscribes to the
+        // returned Mono for each pool slot; defer triggers fresh host selection per subscription.
+        // subscribeOn(boundedElastic): r2dbc-pool runs the allocator on Schedulers.single()
+        // which forbids block(); our load-balanced path needs block() for control-connection
+        // setup and yb_servers() refresh, so we switch to a blocking-capable scheduler.
+        return Mono.defer(() -> {
+            if (isReplicationConnection()) {
+                throw new UnsupportedOperationException("Cannot create replication connection through create(). Use replication() method instead.");
             }
-        }
-        ConnectionStrategy connectionStrategy = ConnectionStrategyFactory.getConnectionStrategy(this.connectionFunction, this.configuration, this.configuration.getConnectionSettings());
-        return doCreateConnection(false, connectionStrategy).cast(io.r2dbc.postgresql.api.PostgresqlConnection.class);
 
+            if (this.configuration.isLoadBalanced()) {
+                Mono<io.r2dbc.postgresql.api.PostgresqlConnection> conn = createLoadBalancedConnection();
+                if (conn != null) {
+                    return conn;
+                }
+            }
+            ConnectionStrategy connectionStrategy = ConnectionStrategyFactory.getConnectionStrategy(this.connectionFunction, this.configuration, this.configuration.getConnectionSettings());
+            return doCreateConnection(false, connectionStrategy).cast(io.r2dbc.postgresql.api.PostgresqlConnection.class);
+        }).subscribeOn(reactor.core.scheduler.Schedulers.boundedElastic());
     }
 
     private synchronized boolean createControlConnection() {

--- a/src/test/java/com/yugabyte/FallbackTopologyTest.java
+++ b/src/test/java/com/yugabyte/FallbackTopologyTest.java
@@ -18,6 +18,7 @@ public class FallbackTopologyTest extends UniformLoadbalancerTest {
         System.out.println("Checking Basic Behaviour...");
         // Start RF=3 cluster with placements 127.0.0.1 -> 2a, 127.0.0.2 -> 2b and 127.0.0.3 -> 2c
         startYBDBCluster();
+        Thread.sleep(10000);
 
         try {
             controlConnection = "127.0.0.3";

--- a/src/test/java/com/yugabyte/TopologyAwarePoolTest.java
+++ b/src/test/java/com/yugabyte/TopologyAwarePoolTest.java
@@ -1,0 +1,135 @@
+package com.yugabyte;
+
+import io.r2dbc.pool.ConnectionPool;
+import io.r2dbc.pool.ConnectionPoolConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionFactory;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+import reactor.core.publisher.Mono;
+
+public class TopologyAwarePoolTest extends FallbackTopologyTest {
+
+    private static final String path = System.getenv("YBDB_PATH");
+    private static final int POOL_SIZE = 12;
+
+    public static void main(String[] args) throws InterruptedException {
+        startYBDBClusterWithSixNodes();
+
+        try {
+            controlConnection = "127.0.0.3";
+
+            // Prefer zone 2a (nodes 1,2): all 12 pool connections land in zone 2a
+            testPoolWithTopologyKeys(
+                "aws.us-west.us-west-2a:1,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c:3",
+                Arrays.asList(6, 6, 0, 0, 0, 0)
+            );
+
+            // Prefer zone 2b (nodes 3,4): all 12 pool connections land in zone 2b
+            testPoolWithTopologyKeys(
+                "aws.us-west.us-west-2b:1,aws.us-west.us-west-2a:2,aws.us-west.us-west-2c:3",
+                Arrays.asList(0, 0, 6, 6, 0, 0)
+            );
+
+            // Prefer zone 2c (nodes 5,6): all 12 pool connections land in zone 2c
+            testPoolWithTopologyKeys(
+                "aws.us-west.us-west-2c:1,aws.us-west.us-west-2a:2,aws.us-west.us-west-2b:3",
+                Arrays.asList(0, 0, 0, 0, 6, 6)
+            );
+
+            // Wildcard matches all zones equally: 2 connections per node
+            testPoolWithTopologyKeys(
+                "aws.us-west.*:1,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c:3",
+                Arrays.asList(2, 2, 2, 2, 2, 2)
+            );
+
+        } finally {
+            executeCmd(path + "/bin/yb-ctl destroy", "Stop YugabyteDB cluster", 10);
+            System.out.println("Done");
+        }
+    }
+
+    private static void testPoolWithTopologyKeys(String topologyKeys, List<Integer> expected) throws InterruptedException {
+        System.out.println("\n--- Testing pool with topology keys: " + topologyKeys + " ---");
+
+        PostgresqlConnectionFactory driverFactory = new PostgresqlConnectionFactory(
+            PostgresqlConnectionConfiguration.builder()
+                .host("127.0.0.3")
+                .port(5433)
+                .database("yugabyte")
+                .username("yugabyte")
+                .password("yugabyte")
+                .loadBalanceHosts(true)
+                .ybServersRefreshInterval(10)
+                .topologyKeys(topologyKeys)
+                .build()
+        );
+
+        ConnectionPoolConfiguration config = ConnectionPoolConfiguration.builder(driverFactory)
+            .initialSize(POOL_SIZE)
+            .maxSize(POOL_SIZE)
+            .maxIdleTime(Duration.ofMinutes(30))
+            .build();
+
+        ConnectionPool pool = new ConnectionPool(config);
+
+        Thread.sleep(5000);
+
+        Mono<String> op1 = runSlowQuery(pool, 1);
+        Mono<String> op2 = runSlowQuery(pool, 2);
+        Mono<String> op3 = runSlowQuery(pool, 3);
+
+        System.out.println("Launching 3 concurrent operations on pool of size " + POOL_SIZE + "...");
+
+        Mono.zip(op1, op2, op3)
+            .doOnSuccess(tuple -> {
+                System.out.println("All 3 operations completed:");
+                System.out.println("  Op1: " + tuple.getT1());
+                System.out.println("  Op2: " + tuple.getT2());
+                System.out.println("  Op3: " + tuple.getT3());
+            })
+            .block();
+
+        verifyConns(expected);
+
+        pool.dispose();
+        Thread.sleep(3000);
+        System.out.println("Pool disposed for topology keys: " + topologyKeys);
+    }
+
+    private static Mono<String> runSlowQuery(ConnectionPool pool, int opId) {
+        return Mono.from(pool.create())
+            .flatMap(connection -> {
+                System.out.println("Op" + opId + ": acquired connection");
+                return Mono.from(connection.createStatement("SELECT pg_sleep(5), " + opId + " AS op_id").execute())
+                    .flatMap(result -> Mono.from(result.map((row, meta) -> "op_id=" + row.get("op_id", Integer.class))))
+                    .doFinally(sig -> {
+                        System.out.println("Op" + opId + ": releasing connection");
+                        Mono.from(connection.close()).subscribe();
+                    });
+            });
+    }
+
+    /**
+     * Nodes 1,2 -> aws.us-west.us-west-2a
+     * Nodes 3,4 -> aws.us-west.us-west-2b
+     * Nodes 5,6 -> aws.us-west.us-west-2c
+     */
+    protected static void startYBDBClusterWithSixNodes() {
+        executeCmd(path + "/bin/yb-ctl destroy", "Stop YugabyteDB cluster", 10);
+        executeCmd(path + "/bin/yb-ctl create --rf 3 --placement_info \"aws.us-west.us-west-2a,aws.us-west.us-west-2a,aws.us-west.us-west-2b\"",
+            "Start YugabyteDB rf=3 cluster", 15);
+        executeCmd(path + "/bin/yb-ctl add_node --placement_info \"aws.us-west.us-west-2b\"",
+            "Add a node", 10);
+        executeCmd(path + "/bin/yb-ctl add_node --placement_info \"aws.us-west.us-west-2c\"",
+            "Add a node", 10);
+        executeCmd(path + "/bin/yb-ctl add_node --placement_info \"aws.us-west.us-west-2c\"",
+            "Add a node", 10);
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException ie) {}
+    }
+}


### PR DESCRIPTION
When using PostgresqlConnectionFactory with [r2dbc-pool](https://github.com/r2dbc/r2dbc-pool), the connection pool fails because:

All pool connections resolve to the same host: r2dbc-pool calls factory.create() once and resubscribes to the returned Mono for each pool slot. Without lazy evaluation, host selection happens only once and is reused for every connection.

block() is not allowed on the pool's scheduler: r2dbc-pool runs its allocator on Schedulers.single(), which forbids blocking calls. The load-balanced code path requires block() for control-connection setup and yb_servers() refresh, causing an IllegalStateException.

Changes

- PostgresqlConnectionFactory.java
  - Wrapped the create() method body in Mono.defer() so that each pool subscription triggers fresh host selection via the load balancer.
  - Added .subscribeOn(Schedulers.boundedElastic()) to move execution off the non-blocking single scheduler, allowing the block() calls required by the load-balanced connection path.

- pom.xml
  - Added r2dbc-pool (1.0.1.RELEASE) as a test-scoped dependency.

- TopologyAwarePoolTest.java (new)
  - Integration test that validates topology-aware load balancing works correctly through an r2dbc-pool ConnectionPool.
    - Starts a 6-node YugabyteDB cluster across 3 availability zones (2a, 2b, 2c).
    - Tests 4 scenarios with different topology key preferences and verifies connection distribution matches expected per-node counts.
    - Runs concurrent queries through the pool to validate end-to-end behavior.

- FallbackTopologyTest.java
  - Added a Thread.sleep(10000) after cluster startup to allow sufficient time for node initialization before running tests.

Test Plan
- Ran existing Smart driver tests.
